### PR TITLE
fix(article): change line clamp

### DIFF
--- a/src/app/_components/preview-article.tsx
+++ b/src/app/_components/preview-article.tsx
@@ -47,7 +47,7 @@ export const PreviewArticle = ({ articles }: PreviewArticleProps) => {
               <h4 className="line-clamp-1 scroll-m-20 break-words text-xl font-semibold tracking-tight">
                 {article.title}
               </h4>
-              <p className="line-clamp-2 text-sm text-muted-foreground">
+              <p className="line-clamp-3 text-sm text-muted-foreground">
                 {extractArticleDescription(article.content)}
               </p>
             </CardContent>


### PR DESCRIPTION
This pull request includes a small change to the `src/app/_components/preview-article.tsx` file. The change adjusts the line-clamp class for article descriptions to display up to three lines instead of two.

* [`src/app/_components/preview-article.tsx`](diffhunk://#diff-457f1e1a92e2d254f82568510ec264d344c40550bcb6f1e6096b45b5b7296621L50-R50): Modified the `PreviewArticle` component to use `line-clamp-3` for the article description paragraph.